### PR TITLE
Remove check for admin in order to reveal/clear numbers

### DIFF
--- a/lib/quick_average_web/live/average_live.html.heex
+++ b/lib/quick_average_web/live/average_live.html.heex
@@ -28,23 +28,21 @@
       <% end %>
     </.simple_form>
 
-    <%= if @is_admin do %>
-      <div class="mb-3">
-        <.button phx-click="clear_clicked">Clear Numbers</.button>
-      </div>
+    <div class="mb-3">
+      <.button phx-click="clear_clicked">Clear Numbers</.button>
+    </div>
 
-      <div class="mb-3">
-        <.input
-          phx-click="reveal_manually"
-          id="is_revealed_manually_toggle"
-          name="is_revealed_manually_toggle"
-          field={@is_revealed_manually}
-          value={@is_revealed_manually}
-          type="toggle"
-          label="Reveal Manually 🎩🐇"
-        />
-      </div>
-    <% end %>
+    <div class="mb-3">
+      <.input
+        phx-click="reveal_manually"
+        id="is_revealed_manually_toggle"
+        name="is_revealed_manually_toggle"
+        field={@is_revealed_manually}
+        value={@is_revealed_manually}
+        type="toggle"
+        label="Reveal Manually 🎩🐇"
+      />
+    </div>
 
     <h2 class="font-semibold text-lg pb-2">
       Average: <%= @average %>


### PR DESCRIPTION
Hey @dewetblomerus!

We are still dutifully using quickaverage, but a common issue we have is the admin randomly going AFK. I thought it might be nice to remove this check and let anyone using quickaverage have the ability to clear/reveal numbers so we don't have to say "Hey <insert name> I think we're just waiting on you to point".

I chose not remove the admin attr from the liveview and any related logic just in case we want to give the admin some powers in the future.

Thanks!

- Jimmy