### PR TITLE
Configure Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,15 +12,21 @@ updates:
     patterns:
       - "*"
     multi-ecosystem-group: "all-dependencies"
+    reviewers:
+      - "dewetblomerus"
 
   - package-ecosystem: "docker"
     directory: "/"
     patterns:
       - "*"
     multi-ecosystem-group: "all-dependencies"
+    reviewers:
+      - "dewetblomerus"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     patterns:
       - "*"
     multi-ecosystem-group: "all-dependencies"
+    reviewers:
+      - "dewetblomerus"


### PR DESCRIPTION
## Summary
- add reviewer assignment to Dependabot updates
- keep Mix, Docker, and GitHub Actions updates grouped into one weekly PR